### PR TITLE
Fixed stacking of Github cards

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -55,7 +55,7 @@ const Markdown = (props) => {
     const GithubStats = (props) => {
         let link = "https://github-readme-stats.vercel.app/api?username=" + props.github + "&show_icons=true"
         if (props.show) {
-            return (<><p align="left">{`<img src="${link}" alt="${props.github}" />`}</p></>);
+            return (<>{`<p align="left"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
         }
         return '';
     }
@@ -86,9 +86,9 @@ const Markdown = (props) => {
         let link = "https://github-readme-stats.vercel.app/api/top-langs/?username=" + props.github + "&layout=compact&hide=html"
         if (props.show) {
             if (!props.showStats) {
-                return (<><p align="center">{`<img src="${link}" alt="${props.github}" />`}</p></>);
+                return (<>{`<p align="center"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
             }
-            return (<><p align="left">{`<img src="${link}" alt="${props.github}" />`}</p></>);
+            return (<>{`<p align="left"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
         }
         return '';
     }

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -55,7 +55,7 @@ const Markdown = (props) => {
     const GithubStats = (props) => {
         let link = "https://github-readme-stats.vercel.app/api?username=" + props.github + "&show_icons=true"
         if (props.show) {
-            return (<>{`<img align="center" src="${link}" alt="${props.github}" />`}<br /><br /></>);
+            return (<><p align="left">{`<img src="${link}" alt="${props.github}" />`}</p></>);
         }
         return '';
     }
@@ -86,9 +86,9 @@ const Markdown = (props) => {
         let link = "https://github-readme-stats.vercel.app/api/top-langs/?username=" + props.github + "&layout=compact&hide=html"
         if (props.show) {
             if (!props.showStats) {
-                return (<>{`<img align="center" src="${link}" alt="${props.github}" />`}<br /><br /></>);
+                return (<><p align="center">{`<img src="${link}" alt="${props.github}" />`}</p></>);
             }
-            return (<>{`<img align="left" src="${link}" alt="${props.github}" />`}<br /><br /></>);
+            return (<><p align="left">{`<img src="${link}" alt="${props.github}" />`}</p></>);
         }
         return '';
     }

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -55,7 +55,7 @@ const Markdown = (props) => {
     const GithubStats = (props) => {
         let link = "https://github-readme-stats.vercel.app/api?username=" + props.github + "&show_icons=true"
         if (props.show) {
-            return (<>{`<p align="left"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
+            return (<>{`<p align="left"><img align="center" src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
         }
         return '';
     }
@@ -86,9 +86,9 @@ const Markdown = (props) => {
         let link = "https://github-readme-stats.vercel.app/api/top-langs/?username=" + props.github + "&layout=compact&hide=html"
         if (props.show) {
             if (!props.showStats) {
-                return (<>{`<p align="center"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
+                return (<>{`<p align="left"><img align="center" src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
             }
-            return (<>{`<p align="left"><img src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
+            return (<>{`<p align="left"><img align="center" src="${link}" alt="${props.github}" /></p>`}<br /><br /></>);
         }
         return '';
     }


### PR DESCRIPTION
Fix for #52 

From my observation, top language card as well as github stats card `img` had an align attribute set to `left` and `center` respectively. 

This, however, has no effect on Github markdown + HTML processor.

IMO, it's better to wrap each of them in `p` tags and align `img` child by setting alignment attributes on `p` tags.