### PR TITLE
[fix]: display config options

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -119,6 +119,7 @@ const IndexPage = () => {
   const [generatePreview, setGeneratePreview] = useState(false)
   const [generateMarkdown, setGenerateMarkdown] = useState(false)
   const [displayLoader, setDisplayLoader] = useState(false)
+  const [showConfig, setShowConfig] = useState(true)
   const [copyObj, setcopyObj] = useState({
     isCopied: false,
     copiedText: "copy-markdown",
@@ -165,6 +166,7 @@ const IndexPage = () => {
   }
 
   const generate = () => {
+    setShowConfig(false)
     var tl = new gsap.timeline()
     tl.to(".generate", {
       scale: 0,
@@ -327,6 +329,7 @@ const IndexPage = () => {
   const handleBackToEdit = () => {
     setGeneratePreview(false)
     setGenerateMarkdown(false)
+    setShowConfig(true)
     gsap.set("#form", {
       display: "",
     })
@@ -610,7 +613,7 @@ const IndexPage = () => {
         <div
           className={
             "w-full shadow flex flex-col justify-center items-start mt-16 border-2 border-solid border-gray-600 py-2 px-4 " +
-            (generateMarkdown || generatePreview ? "hidden" : "block")
+            (!showConfig ? "hidden" : "block")
           }
         >
           <div className="flex justify-between items-center w-full">


### PR DESCRIPTION
To hide config options after clicking `Generate README`