### PR TITLE
Fix #106: add scikit-learn under AI/ML

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -80,7 +80,7 @@ const categorizedSkills = {
 
   ai: {
     title: "AI/ML",
-    skills: ["tensorflow", "pytorch", "opencv"],
+    skills: ["tensorflow", "pytorch", "opencv", "scikit_learn"],
   },
 
   database: {
@@ -354,6 +354,8 @@ const icons = {
     "https://upload.wikimedia.org/wikipedia/commons/b/bb/WxWidgets.svg",
   ember:
     "https://devicons.github.io/devicon/devicon.git/icons/ember/ember-original-wordmark.svg",
+  scikit_learn:
+    "https://upload.wikimedia.org/wikipedia/commons/0/05/Scikit_learn_logo_small.svg",
 }
 
 const initialSkillState = {}


### PR DESCRIPTION
Fixes #106  : Adds scikit-learn under AI / ML section.

### Images after adding:
**Editing mode:**
![Screenshot from 2020-09-23 12-19-39](https://user-images.githubusercontent.com/48756374/93977235-ced25000-fd97-11ea-8de9-d1dc613e26bf.png)

<hr>

**Generated Readme.md:**
![Screenshot from 2020-09-23 12-20-37](https://user-images.githubusercontent.com/48756374/93977241-d0037d00-fd97-11ea-8c2b-874b687ff40e.png)
