### PR TITLE
feat: Added github trophy.

### DIFF
--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -4,19 +4,19 @@ import { latestBlogs } from "../utils/workflows"
 import links from "../constants/page-links"
 import { isMediumUsernameValid } from "../utils/validation"
 
-const AddonsItem = ({inputId, inputChecked, onInputChange, ...props}) => {
+const AddonsItem = ({ inputId, inputChecked, onInputChange, ...props }) => {
   return (
-      <div className="py-2 flex justify-start items-center text-sm sm:text-lg">
-          <label htmlFor={inputId} className="cursor-pointer flex items-center">
-              <input
-                  type="checkbox"
-                  id={inputId}
-                  checked={inputChecked}
-                  onChange={onInputChange}
-              />
-              <span className="pl-4">{props.children}</span>
-          </label>
-      </div>
+    <div className="py-2 flex justify-start items-center text-sm sm:text-lg">
+      <label htmlFor={inputId} className="cursor-pointer flex items-center">
+        <input
+          type="checkbox"
+          id={inputId}
+          checked={inputChecked}
+          onChange={onInputChange}
+        />
+        <span className="pl-4">{props.children}</span>
+      </label>
+    </div>
   )
 }
 
@@ -59,6 +59,13 @@ const Addons = props => {
         onInputChange={() => props.handleCheckChange("visitorsBadge")}
       >
         display visitors count badge
+      </AddonsItem>
+      <AddonsItem
+        inputId="github-profile-trophy"
+        inputChecked={props.data.githubProfileTrophy}
+        onInputChange={() => props.handleCheckChange("githubProfileTrophy")}
+      >
+        display github trophy
       </AddonsItem>
       <AddonsItem
         inputId="github-stats"

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -98,7 +98,7 @@ const Markdown = props => {
     if (props.show) {
       return (
         <>
-          {`<p align="left"> <img src="${link}" alt="${props.github}" /> </p>`}
+          {`<p align="left"> <a href="https://github.com/ryo-ma/github-profile-trophy"><img src="${link}" alt="${props.github}" /></a> </p>`}
           <br />
           <br />
         </>

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -92,6 +92,20 @@ const Markdown = props => {
     }
     return ""
   }
+  const GithubProfileTrophy = props => {
+    let link =
+      "https://github-profile-trophy.vercel.app/?username=" + props.github
+    if (props.show) {
+      return (
+        <>
+          {`<p align="left"> <img src="${link}" alt="${props.github}" /> </p>`}
+          <br />
+          <br />
+        </>
+      )
+    }
+    return ""
+  }
   const GitHubStats = props => {
     let link =
       "https://github-readme-stats.vercel.app/api?username=" +
@@ -208,6 +222,12 @@ const Markdown = props => {
       <>
         <VisitorsBadge
           show={props.data.visitorsBadge}
+          github={props.social.github}
+        />
+      </>
+      <>
+        <GithubProfileTrophy
+          show={props.data.githubProfileTrophy}
           github={props.social.github}
         />
       </>
@@ -424,7 +444,15 @@ const Markdown = props => {
           username={props.social.rssurl}
         />
       </>
-      {isSocial(props.social) ? <>{`</p>`}<br/><br/></> : ""}
+      {isSocial(props.social) ? (
+        <>
+          {`</p>`}
+          <br />
+          <br />
+        </>
+      ) : (
+        ""
+      )}
       <>
         <DisplaySkills skills={props.skills} />
       </>

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -233,6 +233,19 @@ const MarkdownPreview = props => {
     }
     return null
   }
+  const GithubProfileTrophyPreview = props => {
+    let link =
+      "https://github-profile-trophy.vercel.app/?username=" + props.github
+    if (props.show) {
+      return (
+        <div className="text-left my-2">
+          {" "}
+          <img src={link} alt={props.github} />{" "}
+        </div>
+      )
+    }
+    return null
+  }
   const GitHubStatsPreview = props => {
     let link =
       "https://github-readme-stats.vercel.app/api?username=" +
@@ -292,6 +305,10 @@ const MarkdownPreview = props => {
       <SubTitlePreview subtitle={props.data.subtitle} />
       <VisitorsBadgePreview
         show={props.data.visitorsBadge}
+        github={props.social.github}
+      />
+      <GithubProfileTrophyPreview
+        show={props.data.githubProfileTrophy}
         github={props.social.github}
       />
       <WorkPreview work={props} />

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -240,7 +240,9 @@ const MarkdownPreview = props => {
       return (
         <div className="text-left my-2">
           {" "}
-          <img src={link} alt={props.github} />{" "}
+          <a href="https://github.com/ryo-ma/github-profile-trophy">
+            <img src={link} alt={props.github} />
+          </a>{" "}
         </div>
       )
     }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,6 +54,7 @@ const DEFAULT_DATA = {
   contact: "",
   funFact: "",
   visitorsBadge: false,
+  githubProfileTrophy: false,
   githubStats: false,
   topLanguages: false,
   devDynamicBlogs: false,
@@ -221,7 +222,12 @@ const IndexPage = () => {
     trimDataValues(social, setSocial)
     trimDataValues(link, setLink)
     resetCopyMarkdownButton()
-    if (data.visitorsBadge || data.githubStats || data.topLanguages) {
+    if (
+      data.visitorsBadge ||
+      data.githubProfileTrophy ||
+      data.githubStats ||
+      data.topLanguages
+    ) {
       if (social.github && isGitHubUsernameValid(social.github)) {
         generate()
       }
@@ -466,7 +472,10 @@ const IndexPage = () => {
             handleCheckChange={handleCheckChange}
           />
           <div className="section">
-            {(data.visitorsBadge || data.githubStats || data.topLanguages) &&
+            {(data.visitorsBadge ||
+              data.githubProfileTrophy ||
+              data.githubStats ||
+              data.topLanguages) &&
             !social.github ? (
               <div className="warning">
                 * Please add github username to use these add-ons


### PR DESCRIPTION
As mentioned in the issue Id: [89](https://github.com/rahuldkjain/github-profile-readme-generator/issues/89) about the github trophy feat, I've added and option in the add-on. 
1. User can select the option for the github trophy:
![Screenshot 2020-10-02 at 2 17 26 AM](https://user-images.githubusercontent.com/3909648/94861716-998fc700-0455-11eb-9c4a-3a92760a50b5.png)
2. If the github-trophy is selected and the github username is provided then the trophy widget will be added in the generated markdown:
![Screenshot 2020-10-02 at 2 20 21 AM](https://user-images.githubusercontent.com/3909648/94861913-e1aee980-0455-11eb-8c59-bdd71abc4235.png)


