### PR TITLE
Ability to customize the github stats card and top languages

### DIFF
--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -150,6 +150,12 @@ const Addons = props => {
     theme: ""
   });
 
+  useEffect(() => {
+    setGithubStatsOptions({
+      ...props.data.githubStatsOptions
+    })
+  }, [props.data.githubStatsOptions])
+
   const blogPostPorkflow = () => {
     let payload = {
       dev: {

--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -5,55 +5,54 @@ import links from "../constants/page-links"
 import { isMediumUsernameValid, isGitHubUsernameValid } from "../utils/validation"
 import { ToolsIcon, XCircleIcon } from "@primer/octicons-react";
 
-const CustomizeOptions = ({title, CustomizationOptions}) =>  {
-  const [open, setOpen] = useState(false)
-  const Icon = open ? XCircleIcon : ToolsIcon
+const AddonsItem = ({ inputId, inputChecked, onInputChange, Options, onIconClick, ...props }) => {
+  const [open, setOpen] = useState(false);
+  const Icon = open ? XCircleIcon : ToolsIcon;
 
   return (
     <>
-    <button onClick={() => setOpen(!open)} className="flex ml-3 focus:bg-gray-400" style={{outline: "none"}}>
-      <Icon className="transform scale-100 md:scale-125" />
-    </button>
-    {open && <div className={`border-2 border-solid border-gray-900 bg-gray-100 p-2 ml-8`} style={{maxWidth: '21rem'}}>
-      <header className="text-base sm:text-lg">{ title }</header>
-      <hr className="border-gray-500"/>
-      <div className="text-sm sm:text-lg flex flex-col mt-2 ml-0 md:ml-4">
-        {CustomizationOptions}
-      </div>
-    </div>}
-  </>
-  )
-}
-
-const AddonsItem = ({inputId, inputChecked, onInputChange, Icon, onIconClick, ...props}) => {
-  return (
-    <div className="py-2 flex justify-start items-center text-sm sm:text-lg">
-      <label htmlFor={inputId} className="cursor-pointer flex items-center">
-        <input
-          type="checkbox"
-          id={inputId}
-          checked={inputChecked}
-          onChange={onInputChange}
-        />
-        <span className="pl-4">{props.children}</span>
-      </label>
-      {
-        Icon?
-          <button onClick={onIconClick} className="flex ml-3 focus:bg-gray-400" style={{outline: "none"}}>
+      <div className="py-2 flex justify-start items-center text-sm sm:text-lg">
+        <label htmlFor={inputId} className="cursor-pointer flex items-center">
+          <input
+            type="checkbox"
+            id={inputId}
+            checked={inputChecked}
+            onChange={onInputChange}
+          />
+          <span className="pl-4">{props.children}</span>
+        </label>
+        {Options && (
+          <button
+            onClick={() => setOpen(!open)}
+            className="flex ml-3 focus:bg-gray-400"
+            style={{ outline: "none" }}
+          >
             <Icon className="transform scale-100 md:scale-125" />
           </button>
-          :''
-      }
+        )}
+      </div>
+      {Options && open && Options}
+    </>
+  );
+};
+
+const CustomizeOptions = ({ title, CustomizationOptions }) => (
+  <div
+    className={`border-2 border-solid border-gray-900 bg-gray-100 p-2 ml-8`}
+    style={{ maxWidth: "21rem" }}
+  >
+    <header className="text-base sm:text-lg">{title}</header>
+    <hr className="border-gray-500" />
+    <div className="text-sm sm:text-lg flex flex-col mt-2 ml-0 md:ml-4">
+      {CustomizationOptions}
     </div>
-  )
-}
+  </div>
+);
+
 
 const CustomizeBadge = ({githubName, badgeOptions, onBadgeUpdate}) =>  {
   return (
-    <div className={`border-2 border-solid border-gray-900 bg-gray-100 p-2 ml-8`} style={{maxWidth: '21rem'}}>
-      <header className="text-base sm:text-lg">Customize Badge</header>
-      <hr className="border-gray-500"/>
-      <div className="text-sm sm:text-lg flex flex-col mt-2 ml-0 md:ml-4">
+    <>
         <label htmlFor="badge-style">Style:&nbsp;
           <select 
             id="badge-style" 
@@ -103,13 +102,11 @@ const CustomizeBadge = ({githubName, badgeOptions, onBadgeUpdate}) =>  {
           }
           
         </span>
-      </div>
-    </div>
+    </>
   )
 }
 
 const Addons = props => {
-  const [customizeBadgeOpen, setCustomizeOpen] = useState(false);
   const [debounce, setDebounce] = useState(undefined);
   const [badgeOptions, setBadgeOptions] = useState({
     badgeStyle: props.data.badgeStyle, 
@@ -153,10 +150,6 @@ const Addons = props => {
     document.body.removeChild(tempElement)
   }
 
-  const onCustomizeClick = () => {
-    setCustomizeOpen(!customizeBadgeOpen);
-  }
-
   const onBadgeUpdate = (option, value) => {
     const callback = () => {
       let newVal = (option==='badgeLabel' && value==='')?'Profile views':value;
@@ -175,20 +168,21 @@ const Addons = props => {
         inputId="visitors-count"
         inputChecked={props.data.visitorsBadge}
         onInputChange={() => props.handleCheckChange("visitorsBadge")}
-        Icon={ customizeBadgeOpen ? XCircleIcon : ToolsIcon }
-        onIconClick={onCustomizeClick}
+        Options={
+          <CustomizeOptions
+            title="Customize Badge"
+            CustomizationOptions={
+              <CustomizeBadge
+                githubName={props.social.github} 
+                badgeOptions={badgeOptions}
+                onBadgeUpdate={onBadgeUpdate}
+              />
+            }
+          />
+        }
       >
         display visitors count badge
       </AddonsItem>
-      {
-        customizeBadgeOpen?
-          <CustomizeBadge 
-            githubName={props.social.github} 
-            badgeOptions={badgeOptions}
-            onBadgeUpdate={onBadgeUpdate}
-          />
-        : ''
-      }
       <AddonsItem
         inputId="github-profile-trophy"
         inputChecked={props.data.githubProfileTrophy}
@@ -200,9 +194,9 @@ const Addons = props => {
         inputId="github-stats"
         inputChecked={props.data.githubStats}
         onInputChange={() => props.handleCheckChange("githubStats")}
+        Options={<CustomizeOptions title="Customize Github Stats Card" CustomizationOptions={<div>test</div>}/>}
       >
         display github profile stats card
-        <CustomizeOptions title="Customize Github Stats Card" CustomizationOptions={<div>test</div>}/>
       </AddonsItem>
       <AddonsItem
         inputId="top-languages"

--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -108,25 +108,81 @@ const CustomizeBadge = ({githubName, badgeOptions, onBadgeUpdate}) =>  {
 
 const CustomizeGithubStats = ({ githubStatsOptions, onStatsUpdate }) => {
   return (
-    <label htmlFor="github-stats-theme">Theme:&nbsp;
-      <select
-        id="github-stats-theme"
-        onChange={({target: { value }}) => onStatsUpdate("theme", value)}
-        value={githubStatsOptions.theme}
-      >
-        <option value={ null }>none</option>
-        <option value="dark">Dark</option>
-        <option value="radical">Radical</option>
-        <option value="merko">Merko</option>
-        <option value="gruvbox">Gruvbox</option>
-        <option value="tokyonight">Tokyonight</option>
-        <option value="onedark">Onedark</option>
-        <option value="cobalt">Cobalt</option>
-        <option value="synthwave">Synthwave</option>
-        <option value="highcontrast">Highcontrast</option>
-        <option value="dracula">Dracula</option>
-      </select>
-    </label>
+    <>
+      <label htmlFor="github-stats-theme">Theme:&nbsp;
+        <select
+          id="github-stats-theme"
+          onChange={({target: { value }}) => onStatsUpdate("theme", value)}
+          value={githubStatsOptions.theme}
+        >
+          <option value="none">none</option>
+          <option value="dark">Dark</option>
+          <option value="radical">Radical</option>
+          <option value="merko">Merko</option>
+          <option value="gruvbox">Gruvbox</option>
+          <option value="tokyonight">Tokyonight</option>
+          <option value="onedark">Onedark</option>
+          <option value="cobalt">Cobalt</option>
+          <option value="synthwave">Synthwave</option>
+          <option value="highcontrast">Highcontrast</option>
+          <option value="dracula">Dracula</option>
+        </select>
+      </label>
+      <label htmlFor="github-stats-title-color">Title Color:&nbsp;
+        <input
+          type="color"
+          id="github-stats-title-color"
+          defaultValue={`#${githubStatsOptions.titleColor}`}
+          className="w-6"
+          onChange={(e) => onStatsUpdate('titleColor', e.target.value.replace('#', ''))}
+        />
+      </label>
+      <label htmlFor="github-stats-text-color">Text Color:&nbsp;
+        <input
+          type="color"
+          id="github-stats-text-color"
+          defaultValue={`#${githubStatsOptions.textColor}`}
+          className="w-6"
+          onChange={(e) => onStatsUpdate('textColor', e.target.value.replace('#', ''))}
+        />
+      </label>
+      <label htmlFor="github-stats-bg-color">Background Color:&nbsp;
+        <input
+          type="color"
+          id="github-stats-bg-color"
+          defaultValue={`#${githubStatsOptions.bgColor}`}
+          className="w-6"
+          onChange={(e) => onStatsUpdate('bgColor', e.target.value.replace('#', ''))}
+        />
+      </label>
+      <label htmlFor="github-stats-hide-border">Hide border:&nbsp;
+        <input
+          id="github-stats-hide-border"
+          type="checkbox"
+          checked={githubStatsOptions.hideBorder}
+          onChange={(e) => onStatsUpdate('hideBorder', e.target.checked)}
+        />
+      </label>
+      <label htmlFor="github-stats-cache-seconds">Cache Seconds:&nbsp;
+        <input
+          id="github-stats-cache-seconds"
+          type="number"
+          min={1800}
+          max={86400}
+          placeholder={1800}
+          onChange={(e) => onStatsUpdate('cacheSeconds', e.target.value)}
+        />
+      </label>
+      <label htmlFor="github-stats-locale">Locale:&nbsp;
+        <input
+          id="github-stats-locale"
+          type="text"
+          placeholder="en"
+          onChange={(e) => onStatsUpdate('locale', e.target.value)}
+          size="2"
+        />
+      </label>
+    </>
   )
 }
 
@@ -147,7 +203,7 @@ const Addons = props => {
   }, [props.data.badgeStyle, props.data.badgeColor, props.data.badgeLabel])
 
   const [githubStatsOptions, setGithubStatsOptions] = useState({
-    theme: ""
+    ...props.data.githubStatsOptions,
   });
 
   useEffect(() => {

--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -106,14 +106,13 @@ const CustomizeBadge = ({githubName, badgeOptions, onBadgeUpdate}) =>  {
   )
 }
 
-const CustomizeGithubStats = ({ githubStatsOptions, onStatsUpdate }) => {
-  return (
+const CustomizeGithubStatsBase = ({ prefix, options, onUpdate }) =>
     <>
-      <label htmlFor="github-stats-theme">Theme:&nbsp;
+      <label htmlFor={`${prefix}-theme`}>Theme:&nbsp;
         <select
-          id="github-stats-theme"
-          onChange={({target: { value }}) => onStatsUpdate("theme", value)}
-          value={githubStatsOptions.theme}
+          id={`${prefix}-theme`}
+          onChange={({target: { value }}) => onUpdate("theme", value)}
+          defaultValue={options.theme}
         >
           <option value="none">none</option>
           <option value="dark">Dark</option>
@@ -128,63 +127,63 @@ const CustomizeGithubStats = ({ githubStatsOptions, onStatsUpdate }) => {
           <option value="dracula">Dracula</option>
         </select>
       </label>
-      <label htmlFor="github-stats-title-color">Title Color:&nbsp;
+      <label htmlFor={`${prefix}-title-color`}>Title Color:&nbsp;
         <input
           type="color"
-          id="github-stats-title-color"
-          defaultValue={`#${githubStatsOptions.titleColor}`}
+          id={`${prefix}-title-color`}
+          defaultValue={`#${options.titleColor}`}
           className="w-6"
-          onChange={(e) => onStatsUpdate('titleColor', e.target.value.replace('#', ''))}
+          onChange={(e) => onUpdate('titleColor', e.target.value.replace('#', ''))}
         />
       </label>
-      <label htmlFor="github-stats-text-color">Text Color:&nbsp;
+      <label htmlFor={`${prefix}-text-color`}>Text Color:&nbsp;
         <input
           type="color"
-          id="github-stats-text-color"
-          defaultValue={`#${githubStatsOptions.textColor}`}
+          id={`${prefix}-text-color`}
+          defaultValue={`#${options.textColor}`}
           className="w-6"
-          onChange={(e) => onStatsUpdate('textColor', e.target.value.replace('#', ''))}
+          onChange={(e) => onUpdate('textColor', e.target.value.replace('#', ''))}
         />
       </label>
-      <label htmlFor="github-stats-bg-color">Background Color:&nbsp;
+      <label htmlFor={`${prefix}-bg-color`}>Background Color:&nbsp;
         <input
           type="color"
-          id="github-stats-bg-color"
-          defaultValue={`#${githubStatsOptions.bgColor}`}
+          id={`${prefix}-bg-color`}
+          defaultValue={`#${options.bgColor}`}
           className="w-6"
-          onChange={(e) => onStatsUpdate('bgColor', e.target.value.replace('#', ''))}
+          onChange={(e) => onUpdate('bgColor', e.target.value.replace('#', ''))}
         />
       </label>
-      <label htmlFor="github-stats-hide-border">Hide border:&nbsp;
+      <label htmlFor={`${prefix}-hide-border`}>Hide border:&nbsp;
         <input
-          id="github-stats-hide-border"
+          id={`${prefix}-hide-border`}
           type="checkbox"
-          checked={githubStatsOptions.hideBorder}
-          onChange={(e) => onStatsUpdate('hideBorder', e.target.checked)}
+          checked={options.hideBorder}
+          onChange={(e) => onUpdate('hideBorder', e.target.checked)}
         />
       </label>
-      <label htmlFor="github-stats-cache-seconds">Cache Seconds:&nbsp;
+      <label htmlFor={`${prefix}-cache-seconds`}>Cache Seconds:&nbsp;
         <input
-          id="github-stats-cache-seconds"
+          id={`${prefix}-cache-seconds`}
           type="number"
           min={1800}
           max={86400}
           placeholder={1800}
-          onChange={(e) => onStatsUpdate('cacheSeconds', e.target.value)}
+          defaultValue={options.cacheSeconds}
+          onChange={(e) => onUpdate('cacheSeconds', e.target.value)}
         />
       </label>
-      <label htmlFor="github-stats-locale">Locale:&nbsp;
+      <label htmlFor={`${prefix}-locale`}>Locale:&nbsp;
         <input
-          id="github-stats-locale"
+          id={`${prefix}-locale`}
           type="text"
           placeholder="en"
-          onChange={(e) => onStatsUpdate('locale', e.target.value)}
+          defaultValue={options.locale}
+          onChange={(e) => onUpdate('locale', e.target.value)}
           size="2"
         />
       </label>
     </>
-  )
-}
 
 const Addons = props => {
   const [debounce, setDebounce] = useState(undefined);
@@ -211,6 +210,16 @@ const Addons = props => {
       ...props.data.githubStatsOptions
     })
   }, [props.data.githubStatsOptions])
+
+  const [topLanguagesOptions, setTopLanguagesOptions] = useState({
+    ...props.data.topLanguagesOptions,
+  });
+
+  useEffect(() => {
+    setTopLanguagesOptions({
+      ...props.data.topLanguagesOptions
+    })
+  }, [props.data.topLanguagesOptions])
 
   const blogPostPorkflow = () => {
     let payload = {
@@ -256,6 +265,12 @@ const Addons = props => {
     props.handleDataChange("githubStatsOptions", {target: {value: newStatsOptions}})
   }
 
+  const onTopLangUpdate = (option, value) => {
+    const newLangOptions = {...topLanguagesOptions, [option]: value}
+    setTopLanguagesOptions(newLangOptions)
+    props.handleDataChange("topLanguagesOptions", {target: {value: newLangOptions}})
+  }
+
   return (
     <div className="flex justify-center items-start flex-col w-full px-2 sm:px-6 mb-10">
       <div className="text-xl sm:text-2xl font-bold font-title mt-2 mb-2">
@@ -295,7 +310,7 @@ const Addons = props => {
           <CustomizeOptions
             title="Customize Github Stats Card"
             CustomizationOptions={
-          <CustomizeGithubStats githubStatsOptions={githubStatsOptions} onStatsUpdate={onStatsUpdate}/>
+          <CustomizeGithubStatsBase prefix="stats" options={githubStatsOptions} onUpdate={onStatsUpdate}/>
             }
           />
         }
@@ -306,6 +321,14 @@ const Addons = props => {
         inputId="top-languages"
         inputChecked={props.data.topLanguages}
         onInputChange={() => props.handleCheckChange("topLanguages")}
+        Options={
+          <CustomizeOptions
+            title="Customize Top Skills Card"
+            CustomizationOptions={
+            <CustomizeGithubStatsBase prefix="top-lang" options={topLanguagesOptions} onUpdate={onTopLangUpdate}/>
+            }
+          />
+        }
       >
         display top skills
       </AddonsItem>

--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -5,6 +5,26 @@ import links from "../constants/page-links"
 import { isMediumUsernameValid, isGitHubUsernameValid } from "../utils/validation"
 import { ToolsIcon, XCircleIcon } from "@primer/octicons-react";
 
+const CustomizeOptions = ({title, CustomizationOptions}) =>  {
+  const [open, setOpen] = useState(false)
+  const Icon = open ? XCircleIcon : ToolsIcon
+
+  return (
+    <>
+    <button onClick={() => setOpen(!open)} className="flex ml-3 focus:bg-gray-400" style={{outline: "none"}}>
+      <Icon className="transform scale-100 md:scale-125" />
+    </button>
+    {open && <div className={`border-2 border-solid border-gray-900 bg-gray-100 p-2 ml-8`} style={{maxWidth: '21rem'}}>
+      <header className="text-base sm:text-lg">{ title }</header>
+      <hr className="border-gray-500"/>
+      <div className="text-sm sm:text-lg flex flex-col mt-2 ml-0 md:ml-4">
+        {CustomizationOptions}
+      </div>
+    </div>}
+  </>
+  )
+}
+
 const AddonsItem = ({inputId, inputChecked, onInputChange, Icon, onIconClick, ...props}) => {
   return (
     <div className="py-2 flex justify-start items-center text-sm sm:text-lg">
@@ -182,6 +202,7 @@ const Addons = props => {
         onInputChange={() => props.handleCheckChange("githubStats")}
       >
         display github profile stats card
+        <CustomizeOptions title="Customize Github Stats Card" CustomizationOptions={<div>test</div>}/>
       </AddonsItem>
       <AddonsItem
         inputId="top-languages"

--- a/src/components/addons.js
+++ b/src/components/addons.js
@@ -106,6 +106,30 @@ const CustomizeBadge = ({githubName, badgeOptions, onBadgeUpdate}) =>  {
   )
 }
 
+const CustomizeGithubStats = ({ githubStatsOptions, onStatsUpdate }) => {
+  return (
+    <label htmlFor="github-stats-theme">Theme:&nbsp;
+      <select
+        id="github-stats-theme"
+        onChange={({target: { value }}) => onStatsUpdate("theme", value)}
+        value={githubStatsOptions.theme}
+      >
+        <option value={ null }>none</option>
+        <option value="dark">Dark</option>
+        <option value="radical">Radical</option>
+        <option value="merko">Merko</option>
+        <option value="gruvbox">Gruvbox</option>
+        <option value="tokyonight">Tokyonight</option>
+        <option value="onedark">Onedark</option>
+        <option value="cobalt">Cobalt</option>
+        <option value="synthwave">Synthwave</option>
+        <option value="highcontrast">Highcontrast</option>
+        <option value="dracula">Dracula</option>
+      </select>
+    </label>
+  )
+}
+
 const Addons = props => {
   const [debounce, setDebounce] = useState(undefined);
   const [badgeOptions, setBadgeOptions] = useState({
@@ -121,6 +145,10 @@ const Addons = props => {
       badgeLabel: props.data.badgeLabel
     })
   }, [props.data.badgeStyle, props.data.badgeColor, props.data.badgeLabel])
+
+  const [githubStatsOptions, setGithubStatsOptions] = useState({
+    theme: ""
+  });
 
   const blogPostPorkflow = () => {
     let payload = {
@@ -159,6 +187,13 @@ const Addons = props => {
     clearTimeout(debounce);
     setDebounce(setTimeout(callback, 300));
   }
+
+  const onStatsUpdate = (option, value) => {
+    const newStatsOptions = {...githubStatsOptions, [option]: value}
+    setGithubStatsOptions(newStatsOptions)
+    props.handleDataChange("githubStatsOptions", {target: {value: newStatsOptions}})
+  }
+
   return (
     <div className="flex justify-center items-start flex-col w-full px-2 sm:px-6 mb-10">
       <div className="text-xl sm:text-2xl font-bold font-title mt-2 mb-2">
@@ -194,7 +229,14 @@ const Addons = props => {
         inputId="github-stats"
         inputChecked={props.data.githubStats}
         onInputChange={() => props.handleCheckChange("githubStats")}
-        Options={<CustomizeOptions title="Customize Github Stats Card" CustomizationOptions={<div>test</div>}/>}
+        Options={
+          <CustomizeOptions
+            title="Customize Github Stats Card"
+            CustomizationOptions={
+          <CustomizeGithubStats githubStatsOptions={githubStatsOptions} onStatsUpdate={onStatsUpdate}/>
+            }
+          />
+        }
       >
         display github profile stats card
       </AddonsItem>

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { isMediumUsernameValid } from "../utils/validation"
 import { icons, skills, skillWebsites } from "../constants/skills"
+import { githubStatsLinkGenerator } from "../utils/link-generators"
+
 
 const Markdown = props => {
   const Title = props => {
@@ -124,14 +126,10 @@ const Markdown = props => {
     return ""
   }
   const GitHubStats = props => {
-    let link =
-      "https://github-readme-stats.vercel.app/api?username=" +
-      props.github +
-      "&show_icons=true"
     if (props.show) {
       return (
         <>
-          {`<p>&nbsp;<img align="center" src="${link}" alt="${props.github}" /></p>`}
+          {`<p>&nbsp;<img align="center" src="${githubStatsLinkGenerator(props)}" alt="${props.github}" /></p>`}
           <br />
           <br />
         </>
@@ -497,10 +495,10 @@ const Markdown = props => {
         <GitHubStats
           show={props.data.githubStats}
           github={props.social.github}
+          options={props.data.githubStatsOptions}
         />
       </>
     </div>
   )
 }
-
 export default Markdown

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,8 +1,7 @@
 import React from "react"
 import { isMediumUsernameValid } from "../utils/validation"
 import { icons, skills, skillWebsites } from "../constants/skills"
-import { githubStatsLinkGenerator } from "../utils/link-generators"
-
+import { githubStatsLinkGenerator, topLanguagesLinkGenerator } from "../utils/link-generators"
 
 const Markdown = props => {
   const Title = props => {
@@ -125,11 +124,11 @@ const Markdown = props => {
     }
     return ""
   }
-  const GitHubStats = props => {
-    if (props.show) {
+  const GitHubStats = ({ show, github, options }) => {
+    if (show) {
       return (
         <>
-          {`<p>&nbsp;<img align="center" src="${githubStatsLinkGenerator(props)}" alt="${props.github}" /></p>`}
+          {`<p>&nbsp;<img align="center" src="${githubStatsLinkGenerator({github: github, options})}" alt="${github}" /></p>`}
           <br />
           <br />
         </>
@@ -202,15 +201,11 @@ const Markdown = props => {
     return ""
   }
   const DisplayTopLanguages = props => {
-    let link =
-      "https://github-readme-stats.vercel.app/api/top-langs/?username=" +
-      props.github +
-      "&layout=compact"
     if (props.show) {
       if (!props.showStats) {
         return (
           <>
-            {`<p><img align="center" src="${link}" alt="${props.github}" /></p>`}
+            {`<p><img align="center" src="${topLanguagesLinkGenerator({github: props.github, options: props.options})}" alt="${props.github}" /></p>`}
             <br />
             <br />
           </>
@@ -218,7 +213,7 @@ const Markdown = props => {
       }
       return (
         <>
-          {`<p><img align="left" src="${link}" alt="${props.github}" /></p>`}
+          {`<p><img align="left" src="${topLanguagesLinkGenerator({github: props.github, options: props.options })}" alt="${props.github}" /></p>`}
           <br />
           <br />
         </>
@@ -489,6 +484,7 @@ const Markdown = props => {
           show={props.data.topLanguages}
           showStats={props.data.githubStats}
           github={props.social.github}
+          options={props.data.topLanguagesOptions}
         />
       </>
       <>

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { icons, skills, skillWebsites } from "../constants/skills"
-import { githubStatsLinkGenerator } from "../utils/link-generators"
+import { githubStatsLinkGenerator, topLanguagesLinkGenerator } from "../utils/link-generators"
 
 const MarkdownPreview = props => {
   const TitlePreview = props => {
@@ -273,21 +273,17 @@ const MarkdownPreview = props => {
     if (show) {
       return (
         <div className="text-center mx-4 mb-4">
-          <img src={githubStatsLinkGenerator({github, options, show})} alt={github} />
+          <img src={githubStatsLinkGenerator({github, options})} alt={github} />
         </div>
       )
     }
     return null
   }
-  const TopLanguagesPreview = props => {
-    let link =
-      "https://github-readme-stats.vercel.app/api/top-langs/?username=" +
-      props.github +
-      "&layout=compact"
-    if (props.show) {
+  const TopLanguagesPreview = ({github, options, show})=> {
+    if (show) {
       return (
         <div className="text-center mx-4 mb-4">
-          <img src={link} alt={props.github} />
+          <img src={topLanguagesLinkGenerator({github, options})} alt={props.github} />
         </div>
       )
     }
@@ -346,6 +342,7 @@ const MarkdownPreview = props => {
         <TopLanguagesPreview
           show={props.data.topLanguages}
           github={props.social.github}
+          options={props.data.topLanguagesOptions}
         />
         <GitHubStatsPreview
           show={props.data.githubStats}

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { icons, skills, skillWebsites } from "../constants/skills"
+import { githubStatsLinkGenerator } from "../utils/link-generators"
 
 const MarkdownPreview = props => {
   const TitlePreview = props => {
@@ -267,19 +268,12 @@ const MarkdownPreview = props => {
     }
     return null
   }
-  const GitHubStatsPreview = ({github, options, show })=> {
-    const params = {
-      username: github,
-      show_icons: true,
-      ...options.theme && { theme: options.theme }
-    }
-    const query_string = Object.entries(params).map(([key, value]) => `${key}=${value}`).join("&")
-    const link = `https://github-readme-stats.vercel.app/api?${query_string}`
 
+  const GitHubStatsPreview = ({github, options, show })=> {
     if (show) {
       return (
         <div className="text-center mx-4 mb-4">
-          <img src={link} alt={props.github} />
+          <img src={githubStatsLinkGenerator({github, options, show})} alt={github} />
         </div>
       )
     }

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -267,12 +267,16 @@ const MarkdownPreview = props => {
     }
     return null
   }
-  const GitHubStatsPreview = props => {
-    let link =
-      "https://github-readme-stats.vercel.app/api?username=" +
-      props.github +
-      "&show_icons=true"
-    if (props.show) {
+  const GitHubStatsPreview = ({github, options, show })=> {
+    const params = {
+      username: github,
+      show_icons: true,
+      ...options.theme && { theme: options.theme }
+    }
+    const query_string = Object.entries(params).map(([key, value]) => `${key}=${value}`).join("&")
+    const link = `https://github-readme-stats.vercel.app/api?${query_string}`
+
+    if (show) {
       return (
         <div className="text-center mx-4 mb-4">
           <img src={link} alt={props.github} />
@@ -352,6 +356,7 @@ const MarkdownPreview = props => {
         <GitHubStatsPreview
           show={props.data.githubStats}
           github={props.social.github}
+          options={props.data.githubStatsOptions}
         />
       </div>
     </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -73,6 +73,15 @@ const DEFAULT_DATA = {
     locale: "en",
   },
   topLanguages: false,
+  topLanguagesOptions: {
+    theme: "",
+    titleColor: "",
+    textColor: "",
+    bgColor: "",
+    hideBorder: false,
+    cacheSeconds: null,
+    locale: "en",
+  },
   devDynamicBlogs: false,
   mediumDynamicBlogs: false,
   rssDynamicBlogs: false,
@@ -163,7 +172,6 @@ const IndexPage = () => {
   }
 
   const handleDataChange = (field, e) => {
-    debugger
     let change = { ...data }
     change[field] = e.target.value
     setData(change)
@@ -465,7 +473,6 @@ const IndexPage = () => {
       setRestore("")
     }
   }
-console.log(data.githubStatsOptions)
   return (
     <Layout>
       <div className="m-4 sm:p-4">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -64,7 +64,13 @@ const DEFAULT_DATA = {
   githubProfileTrophy: false,
   githubStats: false,
   githubStatsOptions: {
-    theme: ""
+    theme: "",
+    titleColor: "",
+    textColor: "",
+    bgColor: "",
+    hideBorder: false,
+    cacheSeconds: null,
+    locale: "en",
   },
   topLanguages: false,
   devDynamicBlogs: false,
@@ -459,7 +465,7 @@ const IndexPage = () => {
       setRestore("")
     }
   }
-
+console.log(data.githubStatsOptions)
   return (
     <Layout>
       <div className="m-4 sm:p-4">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -63,6 +63,9 @@ const DEFAULT_DATA = {
   badgeLabel: "Profile views",
   githubProfileTrophy: false,
   githubStats: false,
+  githubStatsOptions: {
+    theme: ""
+  },
   topLanguages: false,
   devDynamicBlogs: false,
   mediumDynamicBlogs: false,
@@ -154,6 +157,7 @@ const IndexPage = () => {
   }
 
   const handleDataChange = (field, e) => {
+    debugger
     let change = { ...data }
     change[field] = e.target.value
     setData(change)

--- a/src/utils/link-generators.js
+++ b/src/utils/link-generators.js
@@ -1,6 +1,5 @@
-export const githubStatsLinkGenerator = ({github, options, show}) => {
+const githubStatsStylingQueryString = options => {
   const params = {
-    username: github,
     show_icons: true,
     ...(options.theme && options.theme !== "none") && { theme: options.theme },
     ...options.titleColor && { "title_color": options.titleColor },
@@ -10,8 +9,12 @@ export const githubStatsLinkGenerator = ({github, options, show}) => {
     ...options.cacheSeconds && { "cache_seconds": options.cacheSeconds},
     ...options.locale && { "locale": options.locale},
   }
-  console.log(params);
   const query_string = Object.entries(params).map(([key, value]) => `${key}=${value}`).join("&")
-  const link = `https://github-readme-stats.vercel.app/api?${query_string}`
-  return link
+  return query_string
 }
+
+export const githubStatsLinkGenerator = ({github, options}) =>
+  `https://github-readme-stats.vercel.app/api?username=${github}&${githubStatsStylingQueryString(options)}`
+
+export const topLanguagesLinkGenerator = ({github, options}) =>
+ `https://github-readme-stats.vercel.app/api/top-langs?username=${github}&${githubStatsStylingQueryString(options)}&layout=compact`

--- a/src/utils/link-generators.js
+++ b/src/utils/link-generators.js
@@ -1,0 +1,17 @@
+export const githubStatsLinkGenerator = ({github, options, show}) => {
+  const params = {
+    username: github,
+    show_icons: true,
+    ...(options.theme && options.theme !== "none") && { theme: options.theme },
+    ...options.titleColor && { "title_color": options.titleColor },
+    ...options.textColor && { "text_color": options.textColor},
+    ...options.bgColor && { "bg_color": options.bgColor},
+    ...options.hideBorder && { "hide_border": options.hideBorder},
+    ...options.cacheSeconds && { "cache_seconds": options.cacheSeconds},
+    ...options.locale && { "locale": options.locale},
+  }
+  console.log(params);
+  const query_string = Object.entries(params).map(([key, value]) => `${key}=${value}`).join("&")
+  const link = `https://github-readme-stats.vercel.app/api?${query_string}`
+  return link
+}


### PR DESCRIPTION
This PR includes:
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
Adds the ability to style the github stats and top languages card by adding a customization options card under each. Customize badge was refactored so that the code was reusable for github stats and top lang.

### Added
- `topLanguageOptions` and `githubStatsOptions` to `data` state of index.js
- `utils/link-generators.js` functions to generate the github stats and top language links with selected params cleanly
- `<CustomizeGithubStatsBase>` base component used for both customizing github stats and top lang as both have the same styling options. It is passed different options state and onUpdate functions.

### Changed
- pulled out open/close logic for `customizeBadge` out from `Addons` into `AddonItems`, and customization card wrapper and styling into `<CustomizeOptions>` so they can be reused for customizing github stats and top lang


## Related Tickets & Documents
Fixes  #30

## QA Instructions, Screenshots, Recordings
Added these customization boxes under "display github profile stats card" and "display top skills":
<img width="821" alt="Screen Shot 2020-10-08 at 10 55 21 PM" src="https://user-images.githubusercontent.com/1314446/95536625-6ef3c000-09b9-11eb-8acd-4e535ad974dd.png">
The following selection, with my github user name in:
<img width="697" alt="Screen Shot 2020-10-09 at 4 57 04 AM" src="https://user-images.githubusercontent.com/1314446/95563875-fbb77180-09eb-11eb-8f53-7114ce4f32b1.png">
Will yield:
<img width="974" alt="Screen Shot 2020-10-09 at 4 57 31 AM" src="https://user-images.githubusercontent.com/1314446/95563885-ffe38f00-09eb-11eb-9c83-1a308b03a337.png">
<img width="952" alt="Screen Shot 2020-10-09 at 4 57 18 AM" src="https://user-images.githubusercontent.com/1314446/95563894-0245e900-09ec-11eb-9045-0965e6fbd21c.png">