### PR TITLE
Do not make infinite requests if page is not visible

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -8,19 +8,28 @@ import { Link } from "gatsby"
 import { act } from "react-dom/test-utils"
 
 const Header = props => {
+  const shouldRequestStats = () => {
+    const isFirstRequest = stats.starsCount === 0
+    const isVisible = window.document.visibilityState === 'visible'
+    const hasFocus = window.document.hasFocus()
+    return isFirstRequest || isVisible && hasFocus
+  }
+
   const fetchData = async () => {
-    var response = await axios.get(
-      "https://api.github.com/repos/rahuldkjain/github-profile-readme-generator"
-    )
+    if (shouldRequestStats()) {
+      var response = await axios.get(
+        "https://api.github.com/repos/rahuldkjain/github-profile-readme-generator"
+      )
 
-    const { stargazers_count, forks_count } = response.data
+      const { stargazers_count, forks_count } = response.data
 
-    act(() =>
-      setstats({
-        starsCount: stargazers_count,
-        forksCount: forks_count,
-      })
-    )
+      act(() =>
+        setstats({
+          starsCount: stargazers_count,
+          forksCount: forks_count,
+        })
+      )
+    }
   }
 
   const [stats, setstats] = useState({


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

I've noticed that when I have https://rahuldkjain.github.io/gh-profile-readme-generator opened in browser in background for a long time then I have http errors at requests with 403 status code. If I restart the page I see only zero forks & stars at header because the new request returns with error. After it web-app stops working & debug mode turns on.

![image](https://user-images.githubusercontent.com/32563455/95761803-8088e080-0cb5-11eb-85c8-ebf4df0cb802.png)

I believe that this PR could help with not sending requests if user "forgets" about this page among his tabs. 

**The only thing can be discussed from my perspective shall we send request only if tab is `visible` & `hasFocus` or it's enough only `visible` value.**

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Testcase 1:
1. Open https://rahuldkjain.github.io/gh-profile-readme-generator in separate browser page
2. Open another tab
3. Wait more than 1 min
4. Return to 1 tab
5. We can see only one `http` request in network devtools

Testcase 2:
1. Open https://rahuldkjain.github.io/gh-profile-readme-generator in separate browser page
2. Open another application on laptop
3. Wait more than 1 min
4. Return to 1 tab
5. We can see only one `http` request in network devtools

Testcase 3:
1. Open https://rahuldkjain.github.io/gh-profile-readme-generator in separate browser page
2. Remove `focus` from the page (e.g. press mousebutton anywhere except the browser tab)
3. Wait more than 1 min
4. Return to 1 tab
5. We can see only one `http` request in network devtools

<!-- ## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme

