### PR TITLE
Add GitHub Corner Badge (fork-corner)

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -12,6 +12,13 @@ export default function HTML(props) {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         {props.headComponents}
+        <link 
+          rel="stylesheet" 
+          href="https://cdn.jsdelivr.net/npm/fork-corner/dist/fork-corner.min.css"
+        ></link>
+        <script 
+          src="https://cdn.jsdelivr.net/npm/fork-corner/dist/fork-corner.min.js" defer
+          ></script>
         <script
           data-name="BMC-Widget"
           src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
@@ -25,6 +32,12 @@ export default function HTML(props) {
         ></script>
       </head>
       <body {...props.bodyAttributes}>
+        <a 
+          href="https://github.com/rahuldkjain/github-profile-readme-generator" 
+          target="_blank" 
+          id="fork-corner" 
+          class="fork-corner fc-pos-tr fc-animate-default fc-theme-github"
+        ></a>
         {props.preBodyComponents}
         <div
           key={`body`}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## Description
I add my open-source project called [fork-corner](github.com/warengonzaga/fork-corner) to add a corner badge to the homepage of the profile generator. Since there is a fork button what if use my fork-corner as a GitHub corner banner.

![image](https://user-images.githubusercontent.com/15052701/106356052-80c9ec00-6337-11eb-8bb0-2fe152d994ff.png)

## Related Tickets & Documents
Please see #362 
