### PR TITLE
fix: restore previewMakrdown when back to edit

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -12,7 +12,7 @@ const Header = props => {
     const isFirstRequest = stats.starsCount === 0
     const isVisible = window.document.visibilityState === 'visible'
     const hasFocus = window.document.hasFocus()
-    return isFirstRequest || isVisible && hasFocus
+    return isFirstRequest || (isVisible && hasFocus)
   }
 
   const fetchData = async () => {
@@ -56,7 +56,7 @@ const Header = props => {
   return (
     <div className="shadow flex items-center justify-center flex-col mb-2 py-2">
       <Link to={links.home}>
-        <h1 className="text-base font-bold font-title sm:text-2xl font-medium text-blue-800 flex justify-center items-center flex-col">
+        <h1 className="text-base font-bold font-title sm:text-2xl text-blue-800 flex justify-center items-center flex-col">
           <img
             src={logo}
             className="w-12 h-12"

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -125,7 +125,7 @@ export const SocialPreview = props => {
     const icon_base_url =
     "https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/";
   Object.keys(props.social).forEach(key => {
-    if (props.social[key] && key != "github") viewSocial = true
+    if (props.social[key] && key !== "github") viewSocial = true
   })
   return (
     <div className="flex justify-start items-end flex-wrap">
@@ -315,7 +315,7 @@ export const TwitterBadgePreview = props => {
     return (
       <div className="text-left my-2">
         {" "}
-        <a href="https://twitter.com/${props.twitter}" target="blank">
+        <a href="https://twitter.com/${props.twitter}" target="_blank" rel="noreferrer">
           <img className="h-4 sm:h-6" src={link} alt={props.twitter} />
         </a>{" "}
       </div>
@@ -421,6 +421,7 @@ export const SupportPreview = props => {
           <a
             href={`https://www.buymeacoffee.com/` + props.support.buyMeACoffee}
             target="_blank"
+            rel="noreferrer"
           >
             <img
               src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -305,6 +305,10 @@ const IndexPage = () => {
   const handleBackToEdit = () => {
     setGeneratePreview(false)
     setGenerateMarkdown(false)
+    setPreviewMarkdown({
+      isPreview: false,
+      buttonText: "preview",
+    })
     setShowConfig(true)
     gsap.set("#form", {
       display: "",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
Originally, when in preview mode, clicking `back to edit` will not restore `previewMarkdown`, which causes that incorrect `markdown` button shows rather than `preview` when in `markdown` mode.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
First, click `Generate README`
Then, click `preview`
Then, click `back to edit`
Then, click `Generate README`, which shows `markdown` rather than `preview`

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme

