### PR TITLE
Fix #423 - support field not saved/restored

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -292,7 +292,7 @@ const IndexPage = () => {
     tempElement.setAttribute(
       "href",
       `data:text/json;charset=utf-8,${encodeURIComponent(
-        JSON.stringify({ prefix, data, link, social, skills })
+        JSON.stringify({ prefix, data, link, social, skills, support })
       )}`
     )
     tempElement.setAttribute("download", "data.json")
@@ -367,6 +367,7 @@ const IndexPage = () => {
     setLink(DEFAULT_LINK)
     setSocial(DEFAULT_SOCIAL)
     setSkills(DEFAULT_SKILLS)
+    setSupport(DEFAULT_SUPPORT)
   }
 
   const mergeDefaultWithNewDataSkills = (defaultSkills, newSkills) => {
@@ -396,6 +397,7 @@ const IndexPage = () => {
       setData(restoreData.data || DEFAULT_DATA)
       setLink(restoreData.link || DEFAULT_LINK)
       setSocial(restoreData.social || DEFAULT_SOCIAL)
+      setSupport(restoreData.support || DEFAULT_SUPPORT)
 
       const restoreDataSkills = mergeDefaultWithNewDataSkills(
         DEFAULT_SKILLS,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
Fixes issue #423 
Value in buymeacoffee field is now saved to/restored from JSON and cleared on reset