### PR TITLE
Fix github stats cards not being centered

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -134,7 +134,7 @@ const GitHubStats = ({ show, github, options }) => {
   if (show) {
     return (
       <>
-        {`<p>&nbsp;<img align="center" src="${githubStatsLinkGenerator({
+        {`<p align="center">&nbsp;<img src="${githubStatsLinkGenerator({
           github: github,
           options,
         })}" alt="${github}" /></p>`}
@@ -215,7 +215,7 @@ const DisplayTopLanguages = props => {
     if (!props.showStats) {
       return (
         <>
-          {`<p><img align="center" src="${topLanguagesLinkGenerator({
+          {`<p align="center"><img src="${topLanguagesLinkGenerator({
             github: props.github,
             options: props.options,
           })}" alt="${props.github}" /></p>`}
@@ -241,7 +241,7 @@ const DisplayStreakStats = props => {
   if (props.show) {
     return (
       <>
-        {`<p><img align="center" src="${streakStatsLinkGenerator({
+        {`<p align="center"><img src="${streakStatsLinkGenerator({
           github: props.github,
           options: props.options,
         })}" alt="${props.github}" /></p>`}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
Fixes issue #479, where the github stats cards show as being centered in the markdown preview but when used on github are left aligned.

The issue is the `align="center"` attribute must be on the parent container of the image rather than the image itself to work, which this PR fixes.

## Related Tickets & Documents
https://github.com/rahuldkjain/github-profile-readme-generator/issues/479

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

