### PR TITLE
ci: fix node version to LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: bionic
 language: node_js
 node_js:
-  - "16.10"
+  - "lts/*"
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "lts/*"
+  - "16.10"
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "14"
+  - "lts/*"
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After [#193 ci build](https://app.travis-ci.com/github/rahuldkjain/github-profile-readme-generator/builds/240271936), all ci've failed.
Becuase Node v17 have released, travis CI use v17.0.1.

* [Build 173](https://app.travis-ci.com/github/rahuldkjain/github-profile-readme-generator/builds/238991606) use Node v16.10.0
* [Build 193](https://app.travis-ci.com/github/rahuldkjain/github-profile-readme-generator/builds/240271936) use Node v17.0.1

In [TravisCi docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/), there is no `stable`. So, I specified it to `lts/*`.
