### PR TITLE
Fix broken RSS url generation

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -72,10 +72,11 @@ const DisplayWork = props => {
   return ""
 }
 const DisplaySocial = props => {
+  let link = props.base ? `${props.base}/${props.username}` : props.username;
   if (props.username) {
     return (
       <>
-        {`<a href="${props.base}/${props.username}" target="blank"><img align="center" src="${props.icon}" alt="${props.username}" height="30" width="40" /></a>`}
+        {`<a href="${link}" target="blank"><img align="center" src="${props.icon}" alt="${props.username}" height="30" width="40" /></a>`}
         <br />
       </>
     )

--- a/src/components/markdownPreview.js
+++ b/src/components/markdownPreview.js
@@ -107,10 +107,11 @@ export const WorkPreview = props => {
 
 export const DisplaySocial = props => {
   if (props.username) {
+    let link = props.base ? `${props.base}/${props.username}` : props.username;
     return (
       <a
         className="no-underline text-blue-700 m-2"
-        href={props.base + "/" + props.username}
+        href={link}
         target="blank"
       >
         <img className="w-6 h-6" src={props.icon} alt="props.username" />


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
When you add an RSS url under the social section, the generated url in the markdown has a slash in front of the url, (aka example.com/feed becomes /example.com/feed). This will break the RSS link as the parsed link when clicked will be the github project domain plus the the RSS link (aka github.com/user/project/example.com/feed).

## QA Instructions, Screenshots, Recordings
Simply test adding an RSS link and generate the markdown, the href will have a slash in front of the link. Test this PR and the slash will be gone, and other social links are unaffected and work as normal.

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

