### PR TITLE
bugfix #376: remove forced lower case inputs in socials fields

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -85,7 +85,7 @@ const IndexPage = () => {
 
   const handleSocialChange = (field, e) => {
     const change = { ...social };
-    change[field] = field === 'discord' ? e.target.value : e.target.value.toLowerCase();
+    change[field] = e.target.value;
     setSocial(change);
   };
 


### PR DESCRIPTION
This fixes issue #376 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

There are some Socials that allow for uppercase usernames like below:

Twitter
Discord
YouTube
GitHub

By removing the `toUpperCase` method we can allow users to use both lower case and upper case letters.

## Screenshot
![Screen Shot 2022-03-22 at 7 20 01](https://user-images.githubusercontent.com/20974577/159372808-e90a26af-193d-4a27-ba42-86d56e30f3e1.png)