### PR TITLE
updated django svg link

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -199,7 +199,7 @@ const icons = {
   css3: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg',
   csharp: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg',
   d3js: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/d3js/d3js-original.svg',
-  django: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/django/django-original.svg',
+  django: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/django/django-plain-wordmark.svg',
   docker: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg',
   dotnet: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/dot-net/dot-net-original-wordmark.svg',
   electron: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/electron/electron-original.svg',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
django svg was not loading because devicon updated their icon
updated django svg src  in src/constants/skills.js


## Related Tickets & Documents
Issue #531 

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
