### PR TITLE
Change placeholder from youtube channel name to id

### DIFF
--- a/src/components/__tests__/__snapshots__/social.test.js.snap
+++ b/src/components/__tests__/__snapshots__/social.test.js.snap
@@ -231,7 +231,7 @@ exports[`Social renders correctly 1`] = `
         className="outline-none placeholder-gray-700 w-32 sm:w-1/2 border-t-0 border-l-0 border-r-0 border solid border-gray-900 py-1 px-2 focus:border-blue-700"
         id="youtube"
         onChange={[Function]}
-        placeholder="youtube channel name"
+        placeholder="youtube channel id"
         value="youtube"
       />
     </div>

--- a/src/components/social.jsx
+++ b/src/components/social.jsx
@@ -65,7 +65,7 @@ const Social = (props) => {
         </div>
         <div className="w-1/2 flex justify-center items-center text-xxs sm:text-lg py-4 pr-2 sm:pr-0">
           <img src="https://cdn.jsdelivr.net/npm/simple-icons@3.1.0/icons/youtube.svg" className="w-6 h-6 sm:w-8 sm:h-8 mr-1 sm:mr-4" alt="youtube" />
-          <input id="youtube" placeholder="youtube channel name" className="outline-none placeholder-gray-700 w-32 sm:w-1/2 border-t-0 border-l-0 border-r-0 border solid border-gray-900 py-1 px-2 focus:border-blue-700" value={social.youtube} onChange={(event) => handleSocialChange('youtube', event)} />
+          <input id="youtube" placeholder="youtube channel id" className="outline-none placeholder-gray-700 w-32 sm:w-1/2 border-t-0 border-l-0 border-r-0 border solid border-gray-900 py-1 px-2 focus:border-blue-700" value={social.youtube} onChange={(event) => handleSocialChange('youtube', event)} />
         </div>
         <div className="w-1/2 flex justify-center items-center text-xxs sm:text-lg py-4 pr-2 sm:pr-0">
           <img src="https://cdn.jsdelivr.net/npm/simple-icons@3.1.0/icons/codechef.svg" className="w-6 h-6 sm:w-8 sm:h-8 mr-1 sm:mr-4" alt="codechef" />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## Description
The placeholder for putting in YouTube channel is very confusing as it says 'name' when clearly, you are supposed to put in id.
To make a link to the YouTube channel you use id like "UChTUaMMkavu5hxIA7Gd4kfA" if your YouTube channel is small.
I also got confused between name and id.

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
