### PR TITLE
Replaced Django Icon With Official Logo From Django Website

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -199,7 +199,7 @@ const icons = {
   css3: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg',
   csharp: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg',
   d3js: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/d3js/d3js-original.svg',
-  django: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/django/django-original.svg',
+  django: 'https://static.djangoproject.com/img/logos/django-logo-negative.svg',
   docker: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg',
   dotnet: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/dot-net/dot-net-original-wordmark.svg',
   electron: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/electron/electron-original.svg',


### PR DESCRIPTION
Fixed [bug](https://github.com/rahuldkjain/github-profile-readme-generator/issues/546#issue-1218420683)

Replaced the previous Django faulty icon link which didn't exist with official Django Icon from [Django's Official Site](https://www.djangoproject.com/community/logos/)