### PR TITLE
fix: add a background in express icon 

### DIFF
--- a/src/images/icons/BackendDevelopment/express.svg
+++ b/src/images/icons/BackendDevelopment/express.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48; background-color: 009f38" xml:space="preserve">
 <path d="M48,37.2c-1.7,0.4-2.8,0-3.8-1.4l-6.9-9.5l-1-1.3l-8,10.9c-0.9,1.3-1.9,1.9-3.6,1.4L35,23.4l-9.6-12.5
 	c1.6-0.3,2.8-0.2,3.8,1.3l7.1,9.7l7.2-9.6c0.9-1.3,1.9-1.8,3.6-1.3l-3.7,4.9l-5,6.6c-0.6,0.8-0.5,1.3,0,2L48,37.2z M0,23.1L0.9,19
 	C3.1,10.8,12.6,7.4,19,12.5c3.8,3,4.7,7.2,4.5,11.9H2.2C1.9,32.9,8,38,15.8,35.4c2.7-0.9,4.4-3.1,5.2-5.7c0.4-1.3,1.1-1.6,2.4-1.2


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## Description

This PR add a background to ExpressJS svg icon (in dark mode the old logo was invisible)

## Related Tickets & Documents

Related Issue #643

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
