### PR TITLE
Update Streak Stats to the new link

### DIFF
--- a/src/markdown-pages/addons.md
+++ b/src/markdown-pages/addons.md
@@ -32,7 +32,7 @@ You can customize the theme too. See how to customize yours [here](https://githu
 
 Stay motivated while contributing to open source by displaying your current contribution streak
 
-![rahuldkjain](https://github-readme-streak-stats.herokuapp.com/?user=rahuldkjain)
+![rahuldkjain](https://streak-stats.demolab.com/?user=rahuldkjain)
 
 Developed by by [Jonah Lawrence](https://github.com/DenverCoder1).
 

--- a/src/utils/link-generators.js
+++ b/src/utils/link-generators.js
@@ -34,4 +34,4 @@ export const topLanguagesLinkGenerator = ({ github, options }) =>
   )}&layout=compact`;
 
 export const streakStatsLinkGenerator = ({ github, options }) =>
-  `https://github-readme-streak-stats.herokuapp.com/?user=${github}&${streakStatsStylingQueryString(options)}`;
+  `https://streak-stats.demolab.com/?user=${github}&${streakStatsStylingQueryString(options)}`;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [x] Documentation Update

## Description

Currently, the recommended domain for those who are not self-hosting Streak Stats is https://streak-stats.demolab.com.

It is still hosted on Heroku, but in case I ever decide to take it off Heroku, I can keep https://streak-stats.demolab.com working, but not https://github-readme-streak-stats.herokuapp.com.

New users of Streak Stats should exclusively use the new domain even though the old one is not yet broken.