### PR TITLE
Fix: Fixed spacing between skills images bug

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -260,9 +260,7 @@ const DisplaySkills = (props) => {
     if (skills[skill]) {
       listChosenSkills.push(
         `
-        <a href="${skillWebsites[skill]}" target="_blank" rel="noreferrer">
-          <img src="${icons[skill]}" alt="${skill}" width="40" height="40"/>
-        </a>
+        <a href="${skillWebsites[skill]}" target="_blank" rel="noreferrer"><img src="${icons[skill]}" alt="${skill}" width="40" height="40"/></a>
         `,
       );
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
When you hover of the skills images in the generated markdown, there is a blue underline next to the logo. This PR fixes that spacing, so the blue underline is no more!

## QA Instructions, Screenshots, Recordings

Before
<img width="191" alt="bug-example" src="https://user-images.githubusercontent.com/69229034/220312259-1afc8669-916f-4bd7-b7e4-f27dae1a77f7.png">

After
<img width="191" alt="Screenshot 2023-02-21 at 9 03 07 pm" src="https://user-images.githubusercontent.com/69229034/220313317-9f0d768b-b521-4a90-b7d6-77fcf04ada7d.png">

To replicate
- Select skills
- Generate a MD
- Preview MD
- hover over skills.

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
