### PR TITLE
[FIX] Broken youtube URL

### DIFF
--- a/src/components/markdown.jsx
+++ b/src/components/markdown.jsx
@@ -580,7 +580,7 @@ const Markdown = (props) => {
         <DisplaySocial base="https://medium.com" icon={`${iconBaseUrl}medium.svg`} username={social.medium} />
       </>
       <>
-        <DisplaySocial base="https://www.youtube.com/c" icon={`${iconBaseUrl}youtube.svg`} username={social.youtube} />
+        <DisplaySocial base="https://www.youtube.com/" icon={`${iconBaseUrl}youtube.svg`} username={social.youtube} />
       </>
       <>
         <DisplaySocial

--- a/src/components/markdownPreview.jsx
+++ b/src/components/markdownPreview.jsx
@@ -199,7 +199,7 @@ export const SocialPreview = (props) => {
         <DisplaySocial base="https://medium.com" icon={`${iconBaseUrl}medium.svg`} username={social.medium} />
       </>
       <>
-        <DisplaySocial base="https://www.youtube.com/c" icon={`${iconBaseUrl}youtube.svg`} username={social.youtube} />
+        <DisplaySocial base="https://www.youtube.com/" icon={`${iconBaseUrl}youtube.svg`} username={social.youtube} />
       </>
       <>
         <DisplaySocial


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description
Youtube no longer uses the old random url, it uses a handle like twitter

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Insted of the channel's random id, put its handle with an '@' symbol at the start_

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
