### PR TITLE
feat: make it easy to add uppercase support for more sites

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -27,6 +27,7 @@ import './index.css';
 import { isGitHubUsernameValid, isMediumUsernameValid, isTwitterUsernameValid } from '../utils/validation';
 import { DEFAULT_PREFIX, DEFAULT_DATA, DEFAULT_LINK, DEFAULT_SOCIAL, DEFAULT_SUPPORT } from '../constants/defaults';
 
+const upperCaseSupportedSites = ['discord', 'github'];
 const KeepCacheUpdated = ({ prefix, data, link, social, skills, support }) => {
   useEffect(() => {
     localStorage.setItem(
@@ -93,7 +94,7 @@ const IndexPage = () => {
 
   const handleSocialChange = (field, e) => {
     const change = { ...social };
-    change[field] = field === 'discord' ? e.target.value : e.target.value.toLowerCase();
+    change[field] = upperCaseSupportedSites.includes(field) ? e.target.value : e.target.value.toLowerCase();
     setSocial(change);
   };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation Update

## Description
Some social sites support uppercase characters in their usernames, but we have support only for discord
at the moment. This PR takes care of this by making it easier to add more sites for uppercase support.

## Related Tickets & Documents
Fixes #777

## QA Instructions, Screenshots, Recordings

Navigate to the social section and try adding a username containing uppercase characters. The uppercase character should not be converted to lowercase.

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->
