### PR TITLE
Fix broken icon for Nestjs

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -216,7 +216,7 @@ const icons = {
   meteor: 'https://devicons.github.io/devicon/devicon.git/icons/meteor/meteor-original-wordmark.svg',
   mongodb: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/mongodb/mongodb-original-wordmark.svg',
   mysql: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg',
-  nestjs: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nestjs/nestjs-plain.svg',
+  nestjs: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nestjs/nestjs-original.svg',
   nginx: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nginx/nginx-original.svg',
   nodejs: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original-wordmark.svg',
   openresty: 'https://openresty.org/images/logo.png',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

The current icon URL is [broken](https://raw.githubusercontent.com/devicons/devicon/master/icons/nestjs/nestjs-plain.svg) we need to update the icon URL for Nest.js to https://raw.githubusercontent.com/devicons/devicon/master/icons/nestjs/nestjs-original.svg


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Current URL: 

![image](https://github.com/rahuldkjain/github-profile-readme-generator/assets/3767609/17036277-dc38-483c-93ff-ff3a04d4f6d4)


New URL:

![image](https://github.com/rahuldkjain/github-profile-readme-generator/assets/3767609/c5df0e64-4c30-47df-9417-76ab90a620c8)


<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
