### PR TITLE
fix: update Twitter/X icon

### DIFF
--- a/src/components/social.jsx
+++ b/src/components/social.jsx
@@ -23,7 +23,7 @@ const Social = (props) => {
         </div>
         <div className="w-1/2  flex justify-center items-center text-xxs sm:text-lg py-4 pr-2 sm:pr-0">
           <img
-            src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg"
+            src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/x.svg"
             className="w-6 h-6 sm:w-8 sm:h-8 mr-1 sm:mr-4"
             alt="twitter"
           />


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

This PR updates the Twitter icon in the project, replacing the traditional bird logo with the new X logo as part of the recent rebranding of Twitter. The change involves updating the assets and modifying the related code to reflect the new design.

## Related Tickets & Documents

- Linked issue: [#878 #846 #839 ]

## QA Instructions, Screenshots, Recordings

To verify this change:

1. Check that the new X logo is visible in place of the previous bird icon in the relevant sections of the app or website.
2. Ensure that the icon size, positioning, and clickability are properly maintained after the update.
3. If relevant, check if the new logo’s appearance is responsive across different screen sizes.


---

## Added tests?

- [ ] yes
- [x] no, because the change is related to the icon/branding and doesn't require new tests

## Added to documentation?

- [ ] readme
- [ ] other documentation
- [x] no
