### PR TITLE
Added IOS in Mobile Devs #897

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -76,6 +76,7 @@ const categorizedSkills = {
     title: 'Mobile App Development',
     skills: [
       'android',
+      'ios',
       'flutter',
       'dart',
       'kotlin',
@@ -119,7 +120,7 @@ const categorizedSkills = {
 
   devops: {
     title: 'Devops',
-    skills: ['aws', 'docker', 'jenkins', 'gcp', 'kubernetes', 'bash', 'azure', 'vagrant', 'circleci', 'travisci'],
+    skills: ['aws', 'docker', 'jenkins', 'gcp', 'kubernetes', 'bash', 'azure', 'vagrant', 'circleci', 'travisci', 'xcodecloud'],
   },
 
   baas: {

--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -187,6 +187,8 @@ const icons = {
   aws:
     'https://raw.githubusercontent.com/devicons/devicon/master/icons/amazonwebservices/amazonwebservices-original-wordmark.svg',
   android: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/android/android-original-wordmark.svg',
+  xcodecloud:'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/xcode/xcode-original.svg',
+  ios:'https://raw.githubusercontent.com/devicons/devicon/master/icons/apple/apple-original.svg',
   arduino: 'https://cdn.worldvectorlogo.com/logos/arduino-1.svg',
   backbonejs:
     'https://raw.githubusercontent.com/devicons/devicon/master/icons/backbonejs/backbonejs-original-wordmark.svg',


### PR DESCRIPTION
feat: Added [IOS](https://raw.githubusercontent.com/devicons/devicon/master/icons/apple/apple-original.svg) in mobile_dev and [Xcode Cloud](https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/xcode/xcode-original.svg) in dev_ops in [#897](https://github.com/rahuldkjain/github-profile-readme-generator/issues/897)


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Refactor
- [ ] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

---

## Description

Added **IOS** and **Xcode Cloud** to the available tech stack list:

- ✅ IOS — under *Mobile Development*
- ✅ Xcode Cloud — under *DevOps / CI*

These additions make the github-profile-readme-generator useful for iOS developers as well— a large and active community — by allowing us to showcase relevant tools in our README profiles.

---

## Related Tickets & Documents

Closes [#897](https://github.com/rahuldkjain/github-profile-readme-generator/issues/897)

---

## QA Instructions, Screenshots, Recordings

To test:
1. Run the project locally: `npm install && npm start`
2. Go to the **Tech Stack** section
3. Confirm that `Swift` and `Xcode Cloud` now appear in their respective categories

### Screenshot Preview:
_(Include screenshot if available)_

---

## Added to documentation?

- [ ] readme _(not needed)_