### PR TITLE
 fix: fix VuePress icon with stable SVG

### DIFF
--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -328,7 +328,7 @@ const icons = {
     'https://gist.githubusercontent.com/vivek32ta/c7f7bf583c1fb1c58d89301ea40f37fd/raw/1782aef8672484698c0dd407f900c4a329ed5bc4/sculpin.svg',
   sapper: 'https://raw.githubusercontent.com/bestofjs/bestofjs-webui/master/public/logos/sapper.svg',
   vuepress:
-    'https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/vuepress.svg',
+    "https://raw.githubusercontent.com/devicons/devicon/master/icons/vuejs/vuejs-original.svg",
   unity: 'https://www.vectorlogo.zone/logos/unity3d/unity3d-icon.svg',
   unreal:
     'https://raw.githubusercontent.com/kenangundogan/fontisto/036b7eca71aab1bef8e6a0518f7329f13ed62f6b/icons/svg/brand/unreal-engine.svg',

--- a/src/constants/skills.js
+++ b/src/constants/skills.js
@@ -328,7 +328,7 @@ const icons = {
     'https://gist.githubusercontent.com/vivek32ta/c7f7bf583c1fb1c58d89301ea40f37fd/raw/1782aef8672484698c0dd407f900c4a329ed5bc4/sculpin.svg',
   sapper: 'https://raw.githubusercontent.com/bestofjs/bestofjs-webui/master/public/logos/sapper.svg',
   vuepress:
-    'https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/drivers/webextension/images/icons/VuePress.svg',
+    'https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/vuepress.svg',
   unity: 'https://www.vectorlogo.zone/logos/unity3d/unity3d-icon.svg',
   unreal:
     'https://raw.githubusercontent.com/kenangundogan/fontisto/036b7eca71aab1bef8e6a0518f7329f13ed62f6b/icons/svg/brand/unreal-engine.svg',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Code of Conduct: https://github.com/rahuldkjain/github-profile-readme-generator/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide issue number with link.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

Replaces the broken VuePress icon URL with a stable SVG version provided by the [simple-icons](https://github.com/simple-icons/simple-icons) repository.

Previously, the icon wasn't loading correctly in the "Static Site Generators" section due to a deprecated external link.

## Related Tickets & Documents

Does not apply.

## QA Instructions, Screenshots, Recordings

- Go to the "Static Site Generators" tab in the interface
- Verify that the VuePress icon now displays correctly
- Tested in light and dark themes

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
