### PR TITLE
(.all-contributorsrc): added commas between objects in contributors a…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -49,7 +49,7 @@
       "contributions": [
         "code"
       ]
-    }
+    },
     {
       "login": "YashKandalkar",
       "name": "yash",
@@ -77,7 +77,7 @@
       "contributions": [
         "code"
       ]
-    }
+    },
     {
       "login": "g-savitha",
       "name": "Savitha Gollamudi",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation Update

## Description

Added missing commas between objects in the contributors info array to fix syntax errors.
This ensures the array is valid and can be parsed correctly.

## Related Tickets & Documents

N/A – Syntax correction for contributors array.

## QA Instructions, Screenshots, Recordings

- Open the file (.all-contributorsrc) containing the contributors array.
- Verify that all objects are now separated by commas.
- Run the project → it should compile/run without syntax errors.

<!-- ## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help -->

## Added to documentation?

- [ ] readme
